### PR TITLE
Fix for rustc version 1.87

### DIFF
--- a/src/tauri-dotnet-bridge-host/Cargo.toml
+++ b/src/tauri-dotnet-bridge-host/Cargo.toml
@@ -8,5 +8,5 @@ license = "BSD-3-Clause"
 repository = "https://github.com/plainionist/TauriDotNetBridge"
 
 [dependencies]
-netcorehost = "0.17.0"
+netcorehost = "0.18.0"
 lazy_static = "1.4"


### PR DESCRIPTION
The rustc version 1.87 has broken [dlopen2](https://github.com/OpenByteDev/dlopen2/pull/19) which in turn broke [netcorehost](https://github.com/OpenByteDev/netcorehost/issues/36) dependency.
This updates netcorehost dependency so it works with the newer version of the compiler